### PR TITLE
fix: removed deprecated /auth url path from keycloak config

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -36,7 +36,7 @@ export class KeycloakService {
     const keycloak: any = new KeycloakConnect({}, {
       resource: this.options.clientId,
       realm: this.options.realmName,
-      'auth-server-url': resolve(this.options.baseUrl, '/auth'),
+      'auth-server-url': resolve(this.options.baseUrl),
       secret: this.options.clientSecret,
     } as any)
 


### PR DESCRIPTION
I've noticed that the addition of '/auth' is still there for some endpoints. Since i changed it like in this PR the auth flow works as intended. 

This change is nessessary for keycloak v17+